### PR TITLE
fix bug : update velocity in implicit solver

### DIFF
--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -218,7 +218,7 @@ double Objective::gradient(const Eigen::VectorXd &v, Eigen::VectorXd &grad)
 		Eigen::Vector3d energy_grad(0,0,0);
 
 		for(int j=0; j<node->particles.size(); ++j){
-			energy_grad += node->particles[j]->tempP * node->dwip[j];
+			energy_grad += node->particles[j]->tempP * node->dwip[j] * MPM::timestep_s;
 		}
 
 		if (grad.rows() == v.rows())


### PR DESCRIPTION
I found a small issue in the original code. Referring to the SIGGRAPH course notes, in implicit methods, it is necessary to calculate the gradient of energy with respect to velocity (Formula 205), which is actually the result of Formula 200. Compared to the implementation in the code, I think the gradient calculation result should be added with a time step coefficient. This is my rough opinion. If there are any mistakes, thank you very much for pointing them out.